### PR TITLE
have_been_called_with(any_arg, 'foo') should fail 

### DIFF
--- a/doublex_expects/__init__.py
+++ b/doublex_expects/__init__.py
@@ -4,8 +4,10 @@ from .matchers import (
     have_been_called, have_been_called_with, have_been_satisfied,
     have_been_satisfied_in_any_order, anything, any_arg
 )
+from .exceptions import InvalidApiUsage
+
 
 __all__ = [
     'have_been_called', 'have_been_called_with', 'have_been_satisfied',
-    'have_been_satisfied_in_any_order', 'anything', 'any_arg'
+    'have_been_satisfied_in_any_order', 'anything', 'any_arg', 'InvalidApiUsage'
 ]

--- a/doublex_expects/exceptions.py
+++ b/doublex_expects/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidApiUsage(Exception):
+    pass

--- a/doublex_expects/matchers.py
+++ b/doublex_expects/matchers.py
@@ -4,6 +4,8 @@ from expects import be_above_or_equal, be_below_or_equal
 from expects.matchers import Matcher, default_matcher
 from expects.texts import plain_enumerate
 
+from .exceptions import InvalidApiUsage
+
 MAX_TIMES = be_below_or_equal
 MIN_TIMES = be_above_or_equal
 
@@ -95,6 +97,8 @@ class have_been_called_with(Matcher):
     def _match_args(self, call):
         for i, matcher in enumerate(self._args):
             if matcher is any_arg:
+                if len(self._args) - 1 != i:
+                    raise InvalidApiUsage("ANY_ARG must be the last positional argument")
                 return True
 
             try:

--- a/specs/have_been_called_spec.py
+++ b/specs/have_been_called_spec.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import doublex
-from expects import expect, contain
+from expects import expect
 from expects.testing import failure
 
 from doublex_expects import *

--- a/specs/have_been_called_with_spec.py
+++ b/specs/have_been_called_with_spec.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import doublex
-from expects import expect, be_a, contain
+from expects import expect, be_a, contain, have_keys, raise_error
 from expects.testing import failure
 from expects.texts import plain_enumerate
 
@@ -100,6 +100,14 @@ with describe('have_been_called_with'):
             self.method()
 
             expect(self.method).to(have_been_called_with(any_arg))
+        
+        with it('should fail if exists arguments after'):
+            self.method(self.arg1, self.arg2, self.arg3)
+            
+            expect(lambda: expect(self.method).to(have_been_called_with(any_arg, self.arg2, self.arg3))).to(
+                raise_error(InvalidApiUsage, "ANY_ARG must be the last positional argument"))
+            expect(lambda: expect(self.method).to(have_been_called_with(self.arg1, any_arg, self.arg3))).to(
+                raise_error(InvalidApiUsage, "ANY_ARG must be the last positional argument"))
 
     with describe('once'):
         with it('passes if called with args once'):

--- a/specs/have_been_called_with_spec.py
+++ b/specs/have_been_called_with_spec.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import doublex
-from expects import expect, be_a, contain, have_keys, raise_error
+from expects import expect, be_a, raise_error
 from expects.testing import failure
-from expects.texts import plain_enumerate
 
 from doublex_expects import *
 


### PR DESCRIPTION
This PR resolve #11 raising a new exception when arguments after `any_arg` are found using `have_been_called_with` matcher.